### PR TITLE
Open with utf-8 encoding

### DIFF
--- a/GameInterfaceForToys.py
+++ b/GameInterfaceForToys.py
@@ -165,7 +165,7 @@ class SkyrimScriptInterface(object):
 
     def setup(self):
         try: 
-            fd = open(self.filename, 'r')
+            fd = open(self.filename, 'r', encoding='utf8')
             self._set_eof(fd)
             fd.close()
         except FileNotFoundError:
@@ -383,7 +383,7 @@ class SkyrimScriptInterface(object):
         if stamp != self._cached_stamp:
             try:
                 self._cached_stamp = stamp
-                fd = open(self.filename, 'r')
+                fd = open(self.filename, 'r', encoding='utf8')
                 fd.seek(self.file_pointer, 0)
                 while True:
                     line = fd.readline()
@@ -592,7 +592,7 @@ def load_config():
         except:
             fail("No config value found for {}".format(key))
     try:
-        with io.open('settings.yaml', 'r') as stream:
+        with io.open('settings.yaml', 'r', encoding='utf8') as stream:
             info('Loading Config...')
             data = yaml.safe_load(stream)
             for x in config_fields.values():


### PR DESCRIPTION
Chinese windows system cmd uses gbk encoding by default,
Skyrim uses utf-8 encoding, which causes file reading to fail

The same should happen in Japanese or other East Asian regions

```
[GameInterfaceForToys] [-] Unhandled Exception (<class 'UnicodeDecodeError'>): 'gbk' codec can't decode byte 0xa0 in position 57: illegal multibyte sequence
Traceback (most recent call last):
  File "C:\Users\zoollcar\Desktop\GameInterfaceForToys\GameInterfaceForToys.py", line 505, in main
    await run_task(ssi.parse_log(), run_async=True)
                   ^^^^^^^^^^^^^^^
  File "C:\Users\zoollcar\Desktop\GameInterfaceForToys\GameInterfaceForToys.py", line 407, in parse_log
    raise e
  File "C:\Users\zoollcar\Desktop\GameInterfaceForToys\GameInterfaceForToys.py", line 389, in parse_log
    line = fd.readline()
           ^^^^^^^^^^^^^
```