### PR TITLE
Stack Dump warning use speaker

### DIFF
--- a/GameInterfaceForToys.py
+++ b/GameInterfaceForToys.py
@@ -26,6 +26,7 @@ config_fields = {
     'Toy Type': 'TOY_TYPE',
     'Devious Devices Vib Multiplier': 'DD_VIB_MULT',
     'Warn On Stack Dump': 'WARN_ON_STACK_DUMP',
+    'Warn On Stack Dump SOUND': 'WARN_ON_STACK_DUMP_SOUND',
     'Buttplug.io Strength Max': 'BUTTPLUG_STRENGTH_MAX',
     'Buttplug.io Server Address': 'BUTTPLUG_SERVER_ADDRESS',
     'Chaster Dev Token': 'CHASTER_TOKEN',
@@ -603,6 +604,12 @@ def open_config_modal():
                                   ])
         elif v == 'LOVENSE_USE_NEW_API':
             config_layout.append([sg.Checkbox(k, key=v, default=settings.LOVENSE_USE_NEW_API)])
+        elif v == 'WARN_ON_STACK_DUMP':
+            config_layout.append([sg.Checkbox(k, key=v, default=settings.WARN_ON_STACK_DUMP),
+                                sg.Radio("speaker","WARN_ON_STACK_DUMP_SOUND", key="WARN_ON_STACK_DUMP_SOUND", default=settings.WARN_ON_STACK_DUMP_SOUND),
+                                sg.Radio("buzzer","WARN_ON_STACK_DUMP_SOUND", key="WARN_ON_STACK_DUMP_SOUND", default=not settings.WARN_ON_STACK_DUMP_SOUND)])
+        elif v == 'WARN_ON_STACK_DUMP_SOUND':
+            pass
         else:
             config_layout.append([sg.Text(k), sg.Input(getattr(settings, v), size=(60, 1), key=v)])
     config_layout.append([sg.Button(GUI_CONFIG_SAVE), sg.Button(GUI_CONFIG_EXIT)])

--- a/common/util.py
+++ b/common/util.py
@@ -1,3 +1,6 @@
+from settings import WARN_ON_STACK_DUMP_SOUND
+if WARN_ON_STACK_DUMP_SOUND: import winsound
+
 class colors:
     HEADER = '\033[95m'
     OKBLUE = '\033[94m'
@@ -28,5 +31,6 @@ def fail(s):
 
 def beep():
     print("\a")
+    if WARN_ON_STACK_DUMP_SOUND : winsound.PlaySound('SystemQuestion',winsound.SND_ASYNC)
 
 

--- a/settings.py
+++ b/settings.py
@@ -14,6 +14,7 @@ CHARACTER_NAME = "Min"  # The name of your character.
 TOY_TYPE = []
 DD_VIB_MULT = 2  # Duration of vibration event is multiplied by this value. 
 WARN_ON_STACK_DUMP = True  # Loop short vibrations to notify user of Stack Dumps. Set to False to disable.
+WARN_ON_STACK_DUMP_SOUND = False
 BUTTPLUG_STRENGTH_MAX = 100  # Set to a value between 1 - 100 to cap the strength at a % of your toy's maximum
 BUTTPLUG_SERVER_ADDRESS = "ws://127.0.0.1:12345"  # Whatever Intiface Central says your Server Address is
 


### PR DESCRIPTION
For some laptops, there is no buzzer, so the speaker warning can be an option in the settings。

However, additional dependencies are required: winsound