### PR TITLE
Fix UI blocking after enabling Buttplug.IO

### DIFF
--- a/toys/vibrators/buttplugio/buttplug.py
+++ b/toys/vibrators/buttplugio/buttplug.py
@@ -30,14 +30,12 @@ class ButtplugInterface(Vibrator):
             print("Could not connect to Buttplug.io server, exiting: {}".format(e.message))
             return
 
-        # Immediately scan for devices and just connect whatever we find
+        # Continuously scan for new devices and do not block UI while waiting on the first device
+        # - It is only necessary to stop scanning when we do not want to automatically discover new
+        #   toys as they connect
+        # - Disabling the device scan can be done in the "Intiface Central" application, which runs the
+        #   Buttplug server
         await self.client.start_scanning()
-        await asyncio.sleep(3)
-        while (len(self.client.devices) == 0):
-            print("Searching for devices...")
-            await asyncio.sleep(2)
-        print("Found devices: {}".format(self.client.devices.values()))
-        await self.client.stop_scanning()
 
     async def check_in(self):
         if (self.stop_time > 0 and time.time() > self.stop_time):


### PR DESCRIPTION
Issue:
- Once Buttplug.IO is enabled and a BPIO Server is running, the ui will freeze until at least one client device is connected
- After initial connection new devices are not re-discovered automatically, requiring opening and saving settings again, during short disconnects

Fix: 
- Do not wait for clients to connect and then stop the scan, instead just let the discovery run in the background
- As a result devices are automatically connected and the UI does not freeze waiting for the the first device
- User still has the option to disable scan in Intiface Central, which has to run in the background anyways
