### PR TITLE
YK + Practical Defeat Integration

### DIFF
--- a/data/events/games/skyrim/chaster.yaml
+++ b/data/events/games/skyrim/chaster.yaml
@@ -20,7 +20,14 @@
         min_time: '{CHASTER_DEFEAT_MIN}'
         max_time: '{CHASTER_DEFEAT_MAX}'
 - Acheron - Defeat:
-    regex: ".+OnAcheronDefeatPlayer\(\).+"
+    regex: ".+OnAcheronDefeatPlayer.+"
+    function: generic_chaster_add_time
+    params:
+        min_time: '{CHASTER_DEFEAT_MIN}'
+        max_time: '{CHASTER_DEFEAT_MAX}'
+        
+- Yamete - Struggle Fail:
+    regex: ".+Yamete.+Struggle End.+00000014.+False"
     function: generic_chaster_add_time
     params:
         min_time: '{CHASTER_DEFEAT_MIN}'

--- a/data/events/games/skyrim/chaster.yaml
+++ b/data/events/games/skyrim/chaster.yaml
@@ -24,10 +24,15 @@
     function: generic_chaster_add_time
     params:
         min_time: '{CHASTER_DEFEAT_MIN}'
-        max_time: '{CHASTER_DEFEAT_MAX}'
-        
+        max_time: '{CHASTER_DEFEAT_MAX}' 
 - Yamete - Struggle Fail:
     regex: ".+Yamete.+Struggle End.+00000014.+False"
+    function: generic_chaster_add_time
+    params:
+        min_time: '{CHASTER_DEFEAT_MIN}'
+        max_time: '{CHASTER_DEFEAT_MAX}'
+- Practical Defeat - Struggle Fail:
+    regex: ".+PD.+Victim was defeated"
     function: generic_chaster_add_time
     params:
         min_time: '{CHASTER_DEFEAT_MIN}'


### PR DESCRIPTION
Acheron regex was spitting out errors about Unknown Escape characters, so just removed the escaped parentheses and added .+

Same thing happening for Yamete, so regex is barebones, avoiding all special characters.